### PR TITLE
adding redis support and utils

### DIFF
--- a/redis/redis_counter.go
+++ b/redis/redis_counter.go
@@ -1,0 +1,112 @@
+package rediscounter
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"cloudflare-tinyurl/utils"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var rdb *redis.Client
+
+func InitRedisCounter(redisClient *redis.Client) {
+	rdb = redisClient
+}
+
+// Extracts shortURL from Snowflake ID and updates global counters
+func UpdateGlobalCounter(snowflakeID string) {
+	ctx := context.Background()
+
+	// Extract shortURL from the Snowflake ID
+	shortURL, err := utils.DecodeShortURLFromSnowflakeID(snowflakeID)
+	if err != nil {
+		log.Println("Error extracting shortURL from Snowflake ID:", err)
+		return
+	}
+
+	// Generate Redis keys
+	allTimeKey := fmt.Sprintf("count:%s:all_time", shortURL)
+	last24hKey := fmt.Sprintf("count:%s:24h", shortURL)
+	lastWeekKey := fmt.Sprintf("count:%s:week", shortURL)
+
+	// Atomic counter update
+	err = rdb.Watch(ctx, func(tx *redis.Tx) error {
+		_, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Incr(ctx, allTimeKey)
+			pipe.Incr(ctx, last24hKey)
+			pipe.Expire(ctx, last24hKey, 24*time.Hour) // Set TTL for 24h counter
+			pipe.Incr(ctx, lastWeekKey)
+			pipe.Expire(ctx, lastWeekKey, 7*24*time.Hour) // Set TTL for week counter
+			return nil
+		})
+		return err
+	}, allTimeKey, last24hKey, lastWeekKey)
+
+	if err != nil {
+		log.Println("Error updating global counter:", err)
+	}
+}
+
+// Decrement the global counter ensuring values do not go below zero
+func DecrementGlobalCounter(snowflakeID string) error {
+	ctx := context.Background()
+
+	// Extract shortURL from the Snowflake ID
+	shortURL, err := utils.DecodeShortURLFromSnowflakeID(snowflakeID)
+	if err != nil {
+		log.Println("Error extracting shortURL from Snowflake ID:", err)
+		return err
+	}
+
+	// Generate Redis keys
+	last24hKey := fmt.Sprintf("count:%s:24h", shortURL)
+	lastWeekKey := fmt.Sprintf("count:%s:week", shortURL)
+
+	// Ensure counters do not go below zero
+	err = rdb.Watch(ctx, func(tx *redis.Tx) error {
+		count24h, _ := tx.Get(ctx, last24hKey).Int()
+		countWeek, _ := tx.Get(ctx, lastWeekKey).Int()
+
+		_, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			if count24h > 0 {
+				pipe.Decr(ctx, last24hKey)
+			}
+			if countWeek > 0 {
+				pipe.Decr(ctx, lastWeekKey)
+			}
+			return nil
+		})
+		return err
+	}, last24hKey, lastWeekKey)
+
+	if err != nil {
+		log.Println("Error decrementing global counter:", err)
+	}
+	return err
+}
+
+// Retrieves the count from Redis for a given shortURL
+func GetURLCounter(shortURL string) (int, int, int, error) {
+	ctx := context.Background()
+
+	allTime, err := rdb.Get(ctx, fmt.Sprintf("count:%s:all_time", shortURL)).Int()
+	if err != nil && err != redis.Nil {
+		return 0, 0, 0, err
+	}
+
+	last24h, err := rdb.Get(ctx, fmt.Sprintf("count:%s:24h", shortURL)).Int()
+	if err != nil && err != redis.Nil {
+		return 0, 0, 0, err
+	}
+
+	lastWeek, err := rdb.Get(ctx, fmt.Sprintf("count:%s:week", shortURL)).Int()
+	if err != nil && err != redis.Nil {
+		return 0, 0, 0, err
+	}
+
+	return allTime, last24h, lastWeek, nil
+}

--- a/redis/redis_pubsub.go
+++ b/redis/redis_pubsub.go
@@ -1,0 +1,43 @@
+package redispubsub
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"cloudflare-tinyurl/redisqueue"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var rdb *redis.Client
+
+// Initialize Redis Pub/Sub
+func InitRedisPubSub(redisClient *redis.Client) {
+	rdb = redisClient
+}
+
+// Listen for expired key events and push the full key (snowflake ID) to the queue
+func ListenForExpiredClicks() {
+	pubsub := rdb.PSubscribe(context.Background(), "__keyevent@0__:expired")
+
+	for msg := range pubsub.Channel() {
+		expiredKey := msg.Payload
+
+		// Check if the expired key is a click event
+		if strings.Contains(expiredKey, "click:") {
+			log.Println("Detected expired click event for key:", expiredKey)
+
+			// Push the full key (including snowflake ID) to the processing queue
+			redisqueue.PushExpiredClick(expiredKey)
+		}
+	}
+}
+
+// Publishes a message to Redis Pub/Sub
+func PublishMessage(channel string, message string) {
+	err := rdb.Publish(context.Background(), channel, message).Err()
+	if err != nil {
+		log.Println("Failed to publish message:", err)
+	}
+}

--- a/redis/redis_queue.go
+++ b/redis/redis_queue.go
@@ -1,0 +1,59 @@
+package redisqueue
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"cloudflare-tinyurl/rediscounter"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var rdb *redis.Client
+
+const queueKey = "expired_click_queue" // Shared queue across instances
+
+// Initialize Redis connection
+func InitRedisQueue(redisClient *redis.Client) {
+	rdb = redisClient
+}
+
+// Push an expired click event to the shared queue
+func PushExpiredClick(snowflakeID string) {
+	err := rdb.LPush(context.Background(), queueKey, snowflakeID).Err()
+	if err != nil {
+		log.Println("Failed to push to expired click queue:", err)
+	}
+}
+
+// Processing expired keys
+func ProcessExpiredClicks() {
+	for {
+		// BRPOP ensures only one instance processes each message
+		result, err := rdb.BRPop(context.Background(), 0, queueKey).Result()
+		if err != nil {
+			log.Println("Error processing expired clicks:", err)
+			continue
+		}
+
+		// Use the entire key (Snowflake key with "click:shortURL:snowflakeID")
+		fullKey := result[1]
+		log.Println("Processing expired click event for key:", fullKey)
+
+		// Acquire lock to prevent race conditions
+		lockKey := fmt.Sprintf("lock:%s", fullKey)
+		lockAcquired := acquireLock(lockKey, 2)
+		if !lockAcquired {
+			log.Println("Skipping processing for:", fullKey, "Another instance is handling it.")
+			continue
+		}
+		defer releaseLock(lockKey)
+
+		// Decrement the counters using the full key
+		err = rediscounter.DecrementGlobalCounter(fullKey)
+		if err != nil {
+			log.Println("Error decrementing counters for key:", fullKey, err)
+		}
+	}
+}

--- a/utils/id_generator.go
+++ b/utils/id_generator.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/bwmarrin/snowflake"
+)
+
+var (
+	node *snowflake.Node
+	lock sync.Mutex
+)
+
+// Initializes the Snowflake node
+func InitSnowflake(machineID int64) error {
+	var err error
+	node, err = snowflake.NewNode(machineID)
+	return err
+}
+
+// Generates a Snowflake ID for a click event
+func GenerateSnowflakeID(shortURL string) string {
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Generate a unique Snowflake ID
+	snowflakeID := node.Generate().Int64()
+
+	// Format the key as click:shortURL:snowflakeID
+	return fmt.Sprintf("click:%s:%d", shortURL, snowflakeID)
+}
+
+// Extracts the Snowflake ID from a click key
+func DecodeShortURLFromSnowflakeID(clickKey string) (string, error) {
+	// Example format: "click:shortURL:snowflakeID"
+	parts := strings.Split(clickKey, ":")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid click key format")
+	}
+
+	return parts[1], nil // Extract the shortURL
+}


### PR DESCRIPTION
Adding Redis functionality code and utils:

redis_counter.go -> updates (increments and decrements) the global counters for each url that is been clicked based on three variables time (last 24hrs, last week and all time). it also retrieves the click counts for a given url

redis_pubsub.go -> Listens to the click events expire (TTL) for each url and publishes these events into the redis Queue

redis_queue.go -> Reads the published click events from queue and updates the global counters (decrements)

id_generator -> Used to generate the snowflake id's for each click event  of url


